### PR TITLE
encode emails to avoid missing characters

### DIFF
--- a/src/light-signup.js
+++ b/src/light-signup.js
@@ -38,7 +38,7 @@ export default {
 						'Content-type': 'application/x-www-form-urlencoded'
 					},
 					credentials: 'include',
-					body: `email=${email}`
+					body: `email=${encodeURIComponent(email)}`
 				};
 
 				fetch(url, opts)


### PR DESCRIPTION
@commuterjoy

to avoid the + character being stripped out of signup emails.