### PR TITLE
format the email address correctly

### DIFF
--- a/src/light-signup.js
+++ b/src/light-signup.js
@@ -38,7 +38,7 @@ export default {
 						'Content-type': 'application/x-www-form-urlencoded'
 					},
 					credentials: 'include',
-					body: `email=${encodeURIComponent(email)}`
+					body: `email=${formatEmail(email)}`
 				};
 
 				fetch(url, opts)
@@ -76,6 +76,9 @@ export default {
 			invalidEmailMessage.classList.toggle('n-light-signup__visually-hidden');
 		}
 
+		function formatEmail(email) {
+			return encodeURIComponent(email.trim()).replace('%20', '+');
+		}
 	}
 
 };


### PR DESCRIPTION
@commuterjoy @mclarke47 

* trim whitespace
* encode to URI component
* replace spaces with + signs, because:

> For application/x-www-form-urlencoded, spaces are to be replaced by '+', so one may wish to follow a encodeURIComponent replacement with an additional replacement of "%20" with "+"

Think that catches everything?